### PR TITLE
Added the ability to block eco and standby modes on power off command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ See HELP.md and LICENSE
 * Some rewrite - more scalable, preparing for feedback
 * Added lens movement, zoom, focus, more remote keys and more
 * Added presets for new commands
+
+**V1.1.4**
+* Added the ability to block Standby and Eco modes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "barco-pulse",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"api_version": "1.0.0",
 	"keywords": [
 		"Projector",


### PR DESCRIPTION
When barco pulse projectors get the system.poweroff command, they will keep advancing through power states until it reaches eco mode, where the projector shuts down it's network card. Once it's in eco mode, it can only be turned back on by the remote. 

This PR fixes that by giving the option to block standby and eco mode states in the power off command. 