### PR TITLE
Add Command to Set Illumination and get current value back as Variable

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -290,6 +290,32 @@ module.exports = {
 			}
 		}
 
+/* please add */
+		actions.laser_power = {
+			name: 'Laser power',
+			options: [
+				{
+					type: 'number',
+					id: 'p1',
+					label: 'Laser Power [Steps (15-100)]',
+					min: 15,
+					max: 100,
+					default: 100,
+					required: true,
+					range: false,
+					regex: self.REGEX_NUMBER
+				}
+			],
+			callback: async function (action) {
+				let opt = action.options;
+				let pj_command = 'property.set';
+				let pj_args = { "property": "illumination.sources.laser.power", "value": opt.p1};
+				self.sendCommand(pj_command, pj_args, function() {});
+				
+			}
+		}
+
+
 		actions.lens_calibrate = {
 			name: 'Calibrate lens',
 			options: [

--- a/src/utils.js
+++ b/src/utils.js
@@ -189,5 +189,12 @@ module.exports = {
 			self.checkVariables();
 			self.checkFeedbacks();
 		});
+		
+		/* Laser Power */
+		self.sendCommand("property.get", { "property": "illumination.sources.laser.power" }, function(err, res) {
+			self.INFO['illumination_value'] = res;
+			self.checkVariables();
+			self.checkFeedbacks();
+		});
 	}
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -5,6 +5,7 @@ module.exports = {
 
 		variables.push({ variableId: 'power_state', name: 'Power State' });
 		//variables.push({ variableId: 'illumination_state', name: 'Illumination State' });
+		variables.push({ variableId: 'illumination_value', name: 'Illumination Value' });
 		variables.push({ variableId: 'shutter_position', name: 'Shutter State' });
 
 		variables.push({ variableId: 'identification_family', name: 'Identification Family' });
@@ -23,6 +24,10 @@ module.exports = {
 		try {
 			if ('power_state' in self.INFO) {
 				variableObj['power_state'] = self.INFO['power_state'];
+			}
+
+			if('illumination_value' in self.INFO) {
+				variableObj['illumination_value'] = self.INFO['illumination_value'];
 			}
 
 			if ('illumination_state' in self.INFO) {


### PR DESCRIPTION
This adds a command to set the level of illumination power and recieve the current value as a variable.
If needed an actual feedback could be added, but in our experience this already suffices most met use cases.